### PR TITLE
Enable multi-arch builds, fix image publish builds

### DIFF
--- a/.github/workflows/publish-indy.yml
+++ b/.github/workflows/publish-indy.yml
@@ -29,7 +29,8 @@ jobs:
     name: Publish ACA-Py Image (Indy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
 
       - name: Gather image info
         id: info
@@ -78,6 +79,7 @@ jobs:
             acapy_version=${{ inputs.tag || github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          platforms: linux/amd64,linux/arm64,linux/386
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,8 @@ jobs:
     name: Publish ACA-Py Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
 
       - name: Gather image info
         id: info
@@ -69,6 +70,7 @@ jobs:
             acapy_version=${{ inputs.tag || github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          platforms: linux/amd64,linux/arm64,linux/386
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
+    build-essential \
     bzip2 \
     curl \
     git \
@@ -87,6 +88,9 @@ RUN chmod -R ug+rw $HOME/log $HOME/ledger $HOME/.aries_cloudagent $HOME/.cache
 COPY --from=build /src/dist/aries_cloudagent*.whl .
 
 RUN pip install --no-cache-dir --find-links=. aries_cloudagent${acapy_reqs} && rm aries_cloudagent*.whl
+
+# Clean-up unneccessary build dependencies and reduce final image size
+RUN apt-get purge -y --auto-remove build-essential
 
 USER $user
 

--- a/docker/Dockerfile.indy
+++ b/docker/Dockerfile.indy
@@ -115,6 +115,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
+    build-essential \
     bzip2 \
     curl \
     git \
@@ -256,5 +257,8 @@ RUN chmod -R ug+rw $HOME/.aries_cloudagent
 COPY --from=acapy-builder /src/dist/aries_cloudagent*.whl .
 
 RUN pip install --no-cache-dir --find-links=. aries_cloudagent${acapy_reqs} && rm aries_cloudagent*.whl
+
+# Clean-up unneccessary build dependencies and reduce final image size
+# RUN apt-get purge -y --auto-remove build-essential
 
 ENTRYPOINT ["aca-py"]


### PR DESCRIPTION
Enabled multi-arch builds for image publish gha: targeted architectures are `linux/amd64,linux/arm64,linux/386` as this should cover most enterprise needs, more could be added if deemed necessary.

Added a couple of tweaks to the Dockerfiles that allow the non-Indy build to complete successfully and (for both) clean-up build dependencies before publishing to reduce image size.

Builds complete successfully (reported error is with image publishing, which I have not wired-up for my repo):
- vanilla python build (here)[https://github.com/esune/aries-cloudagent-python/actions/runs/3951471719] - not sure why it reports the 3.9 image being pushed as it has not
- Indy build fails due to a known issue with the postgres plugin (see [here](https://github.com/hyperledger/indy-sdk/issues/2445))

Vanilla builds also seem to fail when run on a M1 chip. haven't been able to track the root cause down.